### PR TITLE
Added syntax highlighting for annotations within method parameters.

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -1061,6 +1061,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#annotations</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#primitive-arrays</string>
 				</dict>
 				<dict>


### PR DESCRIPTION
Fixed an error where annotations within method parameters were not being highlighted properly and was causing problems with the syntax highlighting of variables within the parameters.
