### PR TITLE
Change keyboard shortcut for 'Organize Imports'

### DIFF
--- a/Commands/Organize Imports.tmCommand
+++ b/Commands/Organize Imports.tmCommand
@@ -148,7 +148,7 @@ end
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>
-	<string>~@O</string>
+	<string>^#</string>
 	<key>name</key>
 	<string>Organize Imports</string>
 	<key>output</key>


### PR DESCRIPTION
The original shortcut `cmd-shift-O` conflicts with Textmate-2's shortcut for the `Open Favorites` dialog.  I changed the shortcut to `cmd-option-shift-O`.  This does not seem to conflict with any other commands.
