### PR TITLE
Fixes for the "Create Package Declaration" command.

### DIFF
--- a/Commands/Create Package Declaration.tmCommand
+++ b/Commands/Create Package Declaration.tmCommand
@@ -15,12 +15,12 @@
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
 
 package = []
-package_regex = /$(src|tst)$/ # common source folder names
+package_regex = /^(src|tst)$/ # common source folder names
 package_regex = /^(#{ENV['TM_JAVA_SOURCE_FOLDER_REGEX']})$/ if ENV['TM_JAVA_SOURCE_FOLDER_REGEX']
 dir = ENV['TM_DIRECTORY'] || Dir.getwd
 dir.split(File::SEPARATOR).reverse.each do |folder|
   if folder !~ package_regex
-    package &amp;lt;&amp;lt; folder
+    package &lt;&lt; folder
   else
     break
   end


### PR DESCRIPTION
1. Corrected escaping issue.
2. Fixed regex that determines the default directory to stop at (e.g. src, tst).
