### PR TITLE
Allow comments inside method's signature

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -1104,6 +1104,10 @@
 							<key>include</key>
 							<string>#parameters</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comments</string>
+						</dict>
 					</array>
 				</dict>
 				<dict>
@@ -1143,6 +1147,10 @@
 						<dict>
 							<key>include</key>
 							<string>#all-types</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comments</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Highlight comments inside method's signature (i.e. commented generics for 1.4 downgrade).
