### PR TITLE
Highlight volatile like synchronized

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -1384,7 +1384,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient)\b</string>
+			<string>\b(public|private|protected|static|final|native|synchronized|volatile|abstract|threadsafe|transient)\b</string>
 		</dict>
 		<key>strings</key>
 		<dict>
@@ -1510,7 +1510,7 @@
 					<key>begin</key>
 					<string>(?x:(?=
                         (?:
-                            (?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final) # visibility/modifier
+                            (?:private|protected|public|native|synchronized|volatile|abstract|threadsafe|transient|static|final) # visibility/modifier
                                 |
                             (?:def)
                                 |
@@ -1519,7 +1519,7 @@
                             (?:(?:[a-z]\w*\.)*[A-Z]+\w*) # object type
                         )
                         \s+
-                        (?!private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final|def|void|boolean|byte|char|short|int|float|long|double)
+                        (?!private|protected|public|native|synchronized|volatile|abstract|threadsafe|transient|static|final|def|void|boolean|byte|char|short|int|float|long|double)
                         [\w\d_&lt;&gt;\[\],\?][\w\d_&lt;&gt;\[\],\? \t]*
                         (?:=|$)
                         


### PR DESCRIPTION
This pull request adds `volatile` as a keyword.
It should solve #30.