### PR TITLE
Alter constant keyword order

### DIFF
--- a/Snippets/constant string.tmSnippet
+++ b/Snippets/constant string.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>static public final String ${1:var} = "$2";$0</string>
+	<string>public static final String ${1:var} = "$2";$0</string>
 	<key>name</key>
 	<string>constant string</string>
 	<key>scope</key>

--- a/Snippets/constant.tmSnippet
+++ b/Snippets/constant.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>static public final ${1:String} ${2:var} = $3;$0</string>
+	<string>public static final ${1:String} ${2:var} = $3;$0</string>
 	<key>name</key>
 	<string>constant</string>
 	<key>scope</key>


### PR DESCRIPTION
Most style guidelines recommend that the keywords are in alphabetic order, so rearrange them to be in this order.
Additionally, other snippets use this standard order. (For example, the main snippet.)

See Google's style guidelines: https://google-styleguide.googlecode.com/svn/trunk/javaguide.html#s4.8.7-modifiers
See also the Java Language Specification (where the order is derived from): http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.9