### PR TITLE
Rewrite grammar for Java Properties files.

### DIFF
--- a/Preferences/Indentation Rules - Java Properties.tmPreferences
+++ b/Preferences/Indentation Rules - Java Properties.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Indentation Rules - Properties File</string>
+	<key>scope</key>
+	<string>source.java-properties</string>
+	<key>settings</key>
+	<dict>
+		<key>disableIndentCorrections</key>
+		<true/>
+	</dict>
+	<key>uuid</key>
+	<string>BB1257BA-0871-4B9F-B637-240F884E81E5</string>
+</dict>
+</plist>

--- a/Syntaxes/JavaProperties.plist
+++ b/Syntaxes/JavaProperties.plist
@@ -19,77 +19,58 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>begin</key>
-			<string>(^[ \t]+)?(?=#)</string>
-			<key>beginCaptures</key>
+			<key>comment</key>
+			<string>Ignore blank lines</string>
+			<key>match</key>
+			<string>^\s*$</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#comment-line</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#property-name</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#property-definition</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>comment-line</key>
+		<dict>
+			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.whitespace.comment.leading.java-properties</string>
 				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>patterns</key>
-			<array>
+				<key>2</key>
 				<dict>
-					<key>begin</key>
-					<string>#</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.comment.java-properties</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\n</string>
 					<key>name</key>
-					<string>comment.line.number-sign.java-properties</string>
+					<string>punctuation.definition.comment.java-properties</string>
 				</dict>
-			</array>
+			</dict>
+			<key>match</key>
+			<string>^(\s*)([#!])(.+)?$\n?</string>
+			<key>name</key>
+			<string>comment.line.java-properties</string>
 		</dict>
+		<key>property-definition</key>
 		<dict>
 			<key>begin</key>
-			<string>(^[ \t]+)?(?=!)</string>
+			<string>^(\s*)((?:\\[ \t]|\\:|\\=|[^:=\s])+)(?:\s*([:=]))?\s*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.whitespace.comment.leading.java-properties</string>
+					<string>punctuation.whitespace.leading.java-properties</string>
 				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>!</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.comment.java-properties</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\n</string>
-					<key>name</key>
-					<string>comment.line.exclamation.java-properties</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>^\s*(([\S&amp;&amp;[^:=\\]]|\\.)+)\s*([:=])?</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>support.constant.java-properties</string>
@@ -97,9 +78,15 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\([tnfr"'\\ ]|u\h{4})</string>
+							<string>\\(?:[ \t:=\\ntfr\"']|u[0-9A-Fa-f]{4})</string>
 							<key>name</key>
 							<string>constant.character.escape.java-properties</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\.</string>
+							<key>name</key>
+							<string>invalid.illegal.character.escape.java-properties</string>
 						</dict>
 					</array>
 				</dict>
@@ -109,32 +96,80 @@
 					<string>punctuation.separator.key-value.java-properties</string>
 				</dict>
 			</dict>
+			<key>contentName</key>
+			<string>string.unquoted.java-properties</string>
 			<key>end</key>
-			<string>\n</string>
+			<string>(?&lt;!\\{1})$\n</string>
 			<key>name</key>
-			<string>meta.key-pair.java-properties</string>
+			<string>meta.key-value.java-properties</string>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>(?=\S)</string>
-					<key>end</key>
-					<string>(?&lt;!\\)(?=\n)</string>
+					<key>comment</key>
+					<string>Leading space on a continued line is ignored</string>
+					<key>match</key>
+					<string>^\s*</string>
 					<key>name</key>
-					<string>string.unquoted.java-properties</string>
+					<string>punctuation.whitespace.leading.java-properties</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(\\{1})(?=$\n)</string>
+					<key>name</key>
+					<string>punctuation.separator.continuation.java-properties</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\(?:[\\ntfr\"']|u[0-9A-Fa-f]{4})</string>
+					<key>name</key>
+					<string>constant.character.escape.java-properties</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.character.escape.java-properties</string>
+				</dict>
+			</array>
+		</dict>
+		<key>property-name</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.whitespace.comment.leading.java-properties</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>support.constant.java-properties</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\([tnfr"'\\]|u\h{4}|)</string>
+							<string>\\(?:[ \t:=\\ntfr\"']|u[0-9A-Fa-f]{4})</string>
 							<key>name</key>
 							<string>constant.character.escape.java-properties</string>
 						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\.</string>
+							<key>name</key>
+							<string>invalid.illegal.character.escape.java-properties</string>
+						</dict>
 					</array>
 				</dict>
-			</array>
+			</dict>
+			<key>comment</key>
+			<string>A property name with no value</string>
+			<key>match</key>
+			<string>^(\s*)((?:\\[ \t]|\\:|\\=|[^:=\s])+)(?:\s*([:=]))?\s*$\n</string>
+			<key>name</key>
+			<string>meta.key-value.java-properties</string>
 		</dict>
-	</array>
+	</dict>
 	<key>scopeName</key>
 	<string>source.java-properties</string>
 	<key>uuid</key>

--- a/Syntaxes/JavaProperties.plist
+++ b/Syntaxes/JavaProperties.plist
@@ -82,12 +82,6 @@
 							<key>name</key>
 							<string>constant.character.escape.java-properties</string>
 						</dict>
-						<dict>
-							<key>match</key>
-							<string>\\.</string>
-							<key>name</key>
-							<string>invalid.illegal.character.escape.java-properties</string>
-						</dict>
 					</array>
 				</dict>
 				<key>3</key>
@@ -124,12 +118,6 @@
 					<key>name</key>
 					<string>constant.character.escape.java-properties</string>
 				</dict>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>invalid.illegal.character.escape.java-properties</string>
-				</dict>
 			</array>
 		</dict>
 		<key>property-name</key>
@@ -152,12 +140,6 @@
 							<string>\\(?:[ \t:=\\ntfr\"']|u[0-9A-Fa-f]{4})</string>
 							<key>name</key>
 							<string>constant.character.escape.java-properties</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>\\.</string>
-							<key>name</key>
-							<string>invalid.illegal.character.escape.java-properties</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Recognize line continuations as a separate type of punctuation. Rather than escape sequences.
Better handling for escape sequences in both keys and values.
Display invalid escape sequences.
Handle keys without values correctly.
Add disableIndentCorrections := true for properties files as
indent corrections are more annoying than helpful for this type of file.

I've been using this locally for the last couple of years.  Thought I would see if there is any interest in adding it to the official bundle.
