### PR TITLE
Allow annotations in enumerations

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -920,6 +920,10 @@
 					<key>include</key>
 					<string>#comments</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#annotations</string>
+				</dict>
 			</array>
 		</dict>
 		<key>keywords</key>


### PR DESCRIPTION
Fixes #35.
[Example in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Fjava.tmbundle%2Fc0fb2db554ee56b3ed3921435d1f8d46a52eb91f%2FSyntaxes%2FJava.plist&grammar_text=&code_source=from-text&code_url=&code=package+org.hawkular.client.android.backend.model%3B%0D%0A%0D%0Aimport+com.google.gson.annotations.SerializedName%3B%0D%0A%0D%0Apublic+enum+AlertType+{%0D%0A++++%40SerializedName%28%22THRESHOLD%22%29%0D%0A++++THRESHOLD%2C%0D%0A%0D%0A++++%40SerializedName%28%22AVAILABILITY%22%29%0D%0A++++AVAILABILITY%0D%0A}).

/cc @ming13