### PR TITLE
Support annotations on top-level classes

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -649,6 +649,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#annotations</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#keywords</string>
 				</dict>
 				<dict>


### PR DESCRIPTION
In code like the following, the annotation on the top-level class
is not highlighted like an annotation:

~~~java
@Amazing class Thing {}
~~~

This change fixes that by including the `#annotation` rules
at the top level.