### PR TITLE
Add var as primitive keyword to Java.plist

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -1375,7 +1375,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(?:void|boolean|byte|char|short|int|float|long|double)\b</string>
+					<string>\b(?:void|var|boolean|byte|char|short|int|float|long|double)\b</string>
 					<key>name</key>
 					<string>storage.type.primitive.java</string>
 				</dict>


### PR DESCRIPTION
This PR aims to add the the Java 10 addition "var" to the primitive type keywords. Currently var is not handled at all which makes it look out of place. 
Other syntax highlighters color it like primitives which appears to be the best solution. 

Thanks for the consideration.

