### PR TITLE
Add yield keyword

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -948,7 +948,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(return|break|case|continue|default|do|while|for|switch|if|else)\b</string>
+					<string>\b(return|break|yield|case|continue|default|do|while|for|switch|if|else)\b</string>
 					<key>name</key>
 					<string>keyword.control.java</string>
 				</dict>


### PR DESCRIPTION
Fixes #61 (Has examples of the issue).

Adding the java 13 `yield` keyword. Details of the keyword: https://docs.oracle.com/en/java/javase/13/language/switch-expressions.html

As it's a `break` statement that does `return` a value in a `switch`, I've put it in that block.