### PR TITLE
Add record keyword

### DIFF
--- a/Syntaxes/Java.plist
+++ b/Syntaxes/Java.plist
@@ -431,7 +431,7 @@
 		<key>class</key>
 		<dict>
 			<key>begin</key>
-			<string>(?=\w?[\w\s]*(?:class|(?:@)?interface|enum)\s+\w+)</string>
+			<string>(?=\w?[\w\s]*(?:class|(?:@)?interface|enum|record)\s+\w+)</string>
 			<key>end</key>
 			<string>}</string>
 			<key>endCaptures</key>


### PR DESCRIPTION
As of Java 16 Java supports a new class type known as records. This means a new keyword called "record". Adding this into the Java syntax. for compatibility. This should fix #64.